### PR TITLE
Añadir pruebas y docstrings a client.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
 dist/
+
+# Generated when installing in development mode
+# pip install --editable .
+*.egg-info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Desarrollo y contribuciones
 
+## Ejecucion de pruebas
+
+Para ejecutar las pruebas puede utilizar el comando desde la raíz del projecto:
+
+```bash
+python3 -m unittest tests.test_client
+```
+
+> NOTA: Se recomienda ejecutar la pruebas y verificar que sean exitosas antes
+> de publicar a PyPI
+
 ## Despliegue en PyPI
 
 Tomado de el artículo: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Desarrollo y contribuciones
+
+## Despliegue en PyPI
+
+Tomado de el artículo: 
+
+  * [How to upload your python package to PyPi](https://medium.com/@joel.barmettler/how-to-upload-your-python-package-to-pypi-65edc5fe9c56)
+
+```bash
+pip install twine
+python setup.py sdist
+twine upload dist/*
+```

--- a/README.md
+++ b/README.md
@@ -1,24 +1,73 @@
 # API.datos.gob.mx - cliente de python
 
+Script base para la consulta de datos al API de: 
+
+  * https://api.datos.gob.mx/v2
+
+## Installación
+
+```bash
+pip install --user datosgobmx
+```
+
 ## Uso
-Script base para la consulta de datos al API de https://api.datos.gob.mx/v2
 
-Puedes ejecutar el script con: `python3 client.py`
+### Como librería
 
-Tambien puedes instalarlo directamente con pip: `pip install datosgobmx`
+```python
+import datsogobmx.client as api
 
-Para utilizarlo, puedes primero importar la librería con: `import datosgobmx.client as api`
-y luego hacer llamadas tipo `api.api("endpoint", {"page": 2})`, el segundo parámetro opcional, tiene el formato de query descrito en https://github.com/mxabierto/api#filtros
-
-## Despliegue en PyPI
-
-Tomado de https://medium.com/@joel.barmettler/how-to-upload-your-python-package-to-pypi-65edc5fe9c56
-
+# Retorna una lista de _Endpoints_
+# https://api.datos.gob.mx/v2/api-catalog
+#
+# Cada _Endpoint_ tiene la siguiente estructura, los contenidos de cada endpoint
+# serán distintos:
+#
+# {
+#   "_id": "5cccf090e2705c193281f0aa",
+#   "variables": [
+#     "_id",
+#     "ocid",
+#     "releases",
+#     "compiledRelease"
+#   ],
+#   "count": 300265,
+#   "url": "https://api.datos.gob.mx/v2/Records",
+#   "endpoint": "Records"
+# }
+api_catalog = api()
 ```
-pip install twine
-python setup.py sdist
-twine upload dist/*
+
+Otro ejemplo, para obtener una lista the URLs y endpoints disponibles en la 
+segunda página del catalogo puedes realizar lo siguiente.
+
+```python
+import datsogobmx.client as api
+
+for endpoint in api(query={'page': 2}):
+	print(endpoint['url'], endpoint['endpoint'])
 ```
+
+> NOTA: El método `api` toma un segundo parametro `query` que es un diccionario
+> opcional.
+> Tiene el formato de query descrito en https://github.com/mxabierto/api#filtros
+
+El REST API v2 esta descrito en el siguiente enlace, esto incluye
+los objetos JSON retornados por los endpoints:
+
+  * [API v2](https://github.com/mxabierto/api)
+
+### Como script independiente
+
+Si no se tiene acceso a `pip`, uno puede copiar el script `datosgobmx/client.py`
+a su computadora y directorio de preferencia y ejecutarlo de la siguiente 
+manera:
+
+```bash
+python3 client.py
+```
+
+---
 
 ## Licencia
 Software libre, puede ser redistribuido bajo los términos especificados en nuestra [licencia](https://datos.gob.mx/libreusomx).

--- a/datosgobmx/client.py
+++ b/datosgobmx/client.py
@@ -1,34 +1,85 @@
-#!/usr/bin/python3
-
-import os
-import sys
-import urllib.request
-import json
-import xml.etree.ElementTree as etree
 import re
+import json
 
-def makeCall(endpoint, query={}):
-    """
-    Make a request from api.datos.gob.mx
-    endpoint: one of the endpoints available from https://api.datos.gob.mx
-    query: dict with the query parameters, where no operator means =
-    Example: makeCall('resources',{'pageSize': 1})"""
-    url = "https://api.datos.gob.mx/v2/{endpoint}?".format(endpoint=endpoint)
-    for key in query:
-        operation = "="
-        value = query[key]
-        operator = key
-        regexResult = re.search('(\<|\>)=?', operator)
-        if regexResult is not None:
-            operation = regexResult.group(0)
-            operator = operator[ : (len(operation)*-1) ]
-        url += "{key}{operation}{value}&".format(key=operator, value=value, operation=operation)
-    url = url[:-1]
-    #print("CALL: " + url)
-    with urllib.request.urlopen(url) as response:
-        result = json.loads(response.read().decode("utf-8"))
-        #print(result)
-        return result
+from urllib.request import urlopen
+from urllib.parse import urljoin, quote_plus
+
+BASE_URL = 'https://api.datos.gob.mx/v2/'
 
 def api(endpoint='api-catalog', query={}):
-    return makeCall(endpoint, query)['results']
+    """Returns the `"results"` property from the response of a given endpoint"""
+    return make_call(endpoint, query=query)['results']
+
+
+def make_call(endpoint, query={}):
+    """Make a request to https://api.datos.gob.mx
+
+    :type endpoint: str
+    :param endpoint: One of the endpoints available from https://api.datos.gob.mx
+
+    :type query: dict, optional
+    :param query: A dictionary where the key might include an operator, if no
+        operator is provided "=" is assumed.
+ 
+    :Example: 
+
+    make_call('resource', query={'pageSize': 1})
+    """
+    url = create_url(endpoint, query)
+    with urlopen(url) as response:
+        result = json.loads(response.read().decode("utf-8"))
+        return result
+
+
+def create_url(endpoint='api-catalog', query={}):
+    """Creates a URL using the API's base URL and the user specified endpoint
+    and query.
+    """
+    url = urljoin(BASE_URL, endpoint)
+
+    query_parts = create_query_parts(query)
+
+    if query_parts:
+        url += '?'
+        url += '&'.join(query_parts)
+
+    return url
+
+
+def create_query_parts(query):
+    """Converts the user query dictionary into URL Query string parts
+
+    The query dictionary might contain _operators_ as part of each key, i.e.:
+
+    ```
+    {
+        'count>': 10,
+        'score<=': 11,
+        'page': 1
+    }
+    ```
+
+    This function converts the previous sample to a list of strings that look
+    like this:
+
+    ```
+    ['count>10', 'score<=11', 'page=1']
+    ```
+    """
+    parts = []
+    for key, value in query.items():
+        first_term = key
+        operator = '='
+        second_term = str(value)
+
+        regex_result = re.search('(\<|\>)=?', first_term)
+        if regex_result is not None:
+            operator = regex_result.group(0)
+
+        first_term = first_term.replace(operator, '')
+
+        parts.append('{key}{operator}{value}'.format(
+            key=first_term, operator=operator, value=quote_plus(second_term)
+        ))
+
+    return parts

--- a/datosgobmx/pruebas.py
+++ b/datosgobmx/pruebas.py
@@ -1,4 +1,4 @@
-	#!/usr/bin/python3
+#!/usr/bin/python3
 
 import client as api
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
   name = 'datosgobmx',
   packages = ['datosgobmx'], # this must be the same as the name above
-  version = '0.1.2',
+  version = '0.1.3',
   description = 'Connect to api.datos.gob.mx',
   author = 'Leo Castaneda',
   author_email = 'leonel.castaneda@datos.mx',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,63 @@
+import unittest
+
+from datosgobmx.client import api, create_query_parts, create_url, make_call
+
+class TestClient(unittest.TestCase):
+    def test_create_url(self):
+        """Tests that URL's are created correctly"""
+
+        # Default url
+        result_url = create_url()
+        expected_url = 'https://api.datos.gob.mx/v2/api-catalog'
+        self.assertEqual(expected_url, result_url)
+
+        # Custom endpoint without query
+        result_url = create_url('SOME-OTHER-ENDPOINT')
+        expected_url = 'https://api.datos.gob.mx/v2/SOME-OTHER-ENDPOINT'
+        self.assertEqual(expected_url, result_url)
+
+        # Endpoint with equal query
+        result_url = create_url('SOME-OTHER', query={'page': 1})
+        expected_url = 'https://api.datos.gob.mx/v2/SOME-OTHER?page=1'
+        self.assertEqual(expected_url, result_url)
+
+        # Endpoint with range query
+        result_url = create_url('SOME-OTHER', query={'score>=': 1})
+        expected_url = 'https://api.datos.gob.mx/v2/SOME-OTHER?score>=1'
+        self.assertEqual(expected_url, result_url)
+
+        result_url = create_url('SOME-OTHER', query={
+            'score<=': 1, 'score>=': 11
+        })
+        expected_url = 'https://api.datos.gob.mx/v2/SOME-OTHER?score<=1&score>=11'
+        self.assertEqual(expected_url, result_url)
+
+
+    def test_create_query_parts(self):
+        """Tests that the user query dict is converted correctly to query parts
+        """
+        # Equality - default and explicit
+        query = {
+            "pageSize": "10",
+            "parametro=": "PM2.5",
+            "estacionesid": 300
+        }
+        result_parts = create_query_parts(query)
+        expected_parts = ['pageSize=10', 'parametro=PM2.5', 'estacionesid=300']
+        self.assertEqual(expected_parts, result_parts)
+
+        # Ranges
+        query = {
+            "date-insert>=": "2017-06-29T19:00:00",
+            "date-insert<=": "2017-07-29T19:00:00"
+        }
+        result_parts = create_query_parts(query)
+        expected_parts = [
+            'date-insert>=2017-06-29T19%3A00%3A00', 
+            'date-insert<=2017-07-29T19%3A00%3A00'
+        ]
+        self.assertEqual(expected_parts, result_parts)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hola!, 

He estado utilizando la librería un poco y leyendo su código fuente a fin de tener un poco de más flexibilidad.

Durante su uso, me di cuenta de que en ocasiones requería de acceso a el código que crea 
los _query params_, sin embargo la actual implementación es una sola función.

Siendo un entusiasta del código abierto, decidí contribuir y realizar lo siguiente:

 1. Separar la función `makeCall` en funciones un poco más especificas.
 2. Añadir documentación (docstrings) a dichas funciones.
 3. Remover _packages_ no utilizados en `client.py`
 4. Reemplazar el use the strings para urls con el uso de la libreria `urllib`
 5. Añadir pruebas `unittest` para el modulo `client.py`
 6. Actualizar `client.py` para que esté un poco mas en regla con [PEP8](https://www.python.org/dev/peps/pep-0008/)

Las pruebas puede ser ejecutadas con la siguiente instrucción desde la raíz del proyecto:

```bash
python3 -m unittest tests.test_client
```


